### PR TITLE
Add api_url as input

### DIFF
--- a/.github/validator/team.js
+++ b/.github/validator/team.js
@@ -38,7 +38,8 @@ export default async (field) => {
   // you will need to set the authentication token for the GitHub API so you can
   // read GitHub Teams in your organization.
   const github = new Octokit({
-    auth: core.getInput('github-token', { required: true })
+    auth: core.getInput('github-token', { required: true }),
+    baseUrl: core.getInput('api_url', { required: true })
   })
 
   // In this validator, the only type of input we are expecting is a `string` (a

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ jobs:
 | --------------------- | --------------------------------------------------- |
 | `add-comment`         | Add a [success/failure comment](#comment-templates) |
 |                       | Default: `true`                                     |
+| `api_url`             | The GitHub API URL to use                           |
+|                       | Default: `${{ github.api_url }}`                    |
 | `github-token`        | GitHub PAT for authentication                       |
 |                       | Default: `${{ github.token }}`                      |
 | `issue-form-template` | Template `.yml` file in `.github/ISSUE_TEMPLATE`    |

--- a/__tests__/comments.test.ts
+++ b/__tests__/comments.test.ts
@@ -1,7 +1,9 @@
 import { jest } from '@jest/globals'
+import * as core from '../__fixtures__/core.js'
 import * as github from '../__fixtures__/github.js'
 import * as octokit from '../__fixtures__/octokit.js'
 
+jest.unstable_mockModule('@actions/core', () => core)
 jest.unstable_mockModule('@actions/github', () => github)
 jest.unstable_mockModule('@octokit/rest', async () => {
   class Octokit {
@@ -24,6 +26,10 @@ const { Octokit } = await import('@octokit/rest')
 const mocktokit = jest.mocked(new Octokit())
 
 describe('getCommentId()', () => {
+  beforeEach(() => {
+    core.getInput.mockReset().mockReturnValueOnce('https://api.github.com')
+  })
+
   afterEach(() => {
     jest.resetAllMocks()
   })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -71,6 +71,7 @@ describe('main.ts', () => {
 
     core.getInput
       .mockReturnValueOnce('true') // add-comment
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('1') // issue-number
       .mockReturnValueOnce(parsedIssue) // parsed-issue-body
       .mockReturnValueOnce('issue-ops/validator') // repository
@@ -115,6 +116,7 @@ describe('main.ts', () => {
     core.getInput
       .mockReset()
       .mockReturnValueOnce('false') // add-comment
+      .mockReturnValueOnce('https://api.github.com') // api_url
       .mockReturnValueOnce('1') // issue-number
       .mockReturnValueOnce(parsedIssue) // parsed-issue-body
       .mockReturnValueOnce('issue-ops/validator') // repository

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: Whether to comment on the issue with a success/failure message
     required: false
     default: 'true'
+  api_url:
+    description: The GitHub API URL to use.
+    required: false
+    default: ${{ github.api_url }}
   github-token:
     description: The GitHub API token to use
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -34600,7 +34600,9 @@ const COMMENT_IDENTIFIER = `<!-- validator: workflow=${githubExports.context.wor
  * @returns The ID of the previous validator result comment, or undefined
  */
 async function getCommentId(token, owner, repo, issueNumber) {
-    const octokit = githubExports.getOctokit(token);
+    const octokit = githubExports.getOctokit(token, {
+        baseUrl: coreExports.getInput('api_url', { required: true })
+    });
     // If no existing comment is found, set the result to undefined.
     let commentId = undefined;
     const response = await octokit.paginate(octokit.rest.issues.listComments, {
@@ -50838,6 +50840,7 @@ async function run() {
     const addComment = coreExports.getInput('add-comment', {
         required: true
     }) === 'true';
+    const apiUrl = coreExports.getInput('api_url', { required: true });
     const issueNumber = parseInt(coreExports.getInput('issue-number', { required: true }), 10);
     const parsedIssue = JSON.parse(coreExports.getInput('parsed-issue-body', { required: true }));
     const repository = coreExports.getInput('repository', {
@@ -50853,6 +50856,7 @@ async function run() {
     const repo = repository.split('/')[1];
     coreExports.info('Running action with the following inputs:');
     coreExports.info(`  addComment: ${addComment}`);
+    coreExports.info(`  apiUrl: ${apiUrl}`);
     coreExports.info(`  issueNumber: ${issueNumber}`);
     coreExports.info(`  parsedIssue: ${JSON.stringify(parsedIssue)}`);
     coreExports.info(`  repository: ${repository}`);
@@ -50903,7 +50907,7 @@ async function run() {
         }
         // Add the identifier to the comment body.
         body += `\n\nThis comment will be automatically updated the next time the validator runs.\n\n${COMMENT_IDENTIFIER}`;
-        const octokit = new Octokit$1({ auth: token });
+        const octokit = new Octokit$1({ auth: token, baseUrl: apiUrl });
         if (commentId !== undefined) {
             await octokit.rest.issues.updateComment({
                 owner,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "issue-ops-validator",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "issue-ops-validator",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "issue-ops-validator",
   "description": "Validate issue form submissions",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "author": "Nick Alteen <ncalteen@github.com>",
   "type": "module",
   "homepage": "https://github.com/issue-ops/validator#readme",

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,3 +1,4 @@
+import * as core from '@actions/core'
 import * as github from '@actions/github'
 import { COMMENT_IDENTIFIER } from './constants.js'
 
@@ -14,7 +15,9 @@ export async function getCommentId(
   repo: string,
   issueNumber: number
 ): Promise<number | undefined> {
-  const octokit = github.getOctokit(token)
+  const octokit = github.getOctokit(token, {
+    baseUrl: core.getInput('api_url', { required: true })
+  })
 
   // If no existing comment is found, set the result to undefined.
   let commentId: number | undefined = undefined

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ export async function run(): Promise<void> {
     core.getInput('add-comment', {
       required: true
     }) === 'true'
+  const apiUrl: string = core.getInput('api_url', { required: true })
   const issueNumber: number = parseInt(
     core.getInput('issue-number', { required: true }),
     10
@@ -40,6 +41,7 @@ export async function run(): Promise<void> {
 
   core.info('Running action with the following inputs:')
   core.info(`  addComment: ${addComment}`)
+  core.info(`  apiUrl: ${apiUrl}`)
   core.info(`  issueNumber: ${issueNumber}`)
   core.info(`  parsedIssue: ${JSON.stringify(parsedIssue)}`)
   core.info(`  repository: ${repository}`)
@@ -106,7 +108,7 @@ export async function run(): Promise<void> {
     // Add the identifier to the comment body.
     body += `\n\nThis comment will be automatically updated the next time the validator runs.\n\n${COMMENT_IDENTIFIER}`
 
-    const octokit = new Octokit({ auth: token })
+    const octokit = new Octokit({ auth: token, baseUrl: apiUrl })
 
     if (commentId !== undefined) {
       await octokit.rest.issues.updateComment({


### PR DESCRIPTION
This pull request introduces support for custom GitHub API URLs in the `issue-ops-validator` project. The most significant changes include updates to the authentication mechanism, new input handling for the `api_url` parameter, and test adjustments to validate the new functionality.